### PR TITLE
Running lulu with the coolstar "Full ROM" presents with DMI System

### DIFF
--- a/chromebook_kb_backlight.c
+++ b/chromebook_kb_backlight.c
@@ -73,7 +73,16 @@ static struct dmi_system_id __initdata chromebook_kb_backlight_dmi_table[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "Lulu"),
 		},
 		.callback = setup_keyboard_backlight,
-	}, { }
+	}, 
+	{
+		.ident = "Dell Chromebook 13 - Keyboard backlight",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Google"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Lulu"),
+		},
+		.callback = setup_keyboard_backlight,
+	}, 
+    { }
 };
 MODULE_DEVICE_TABLE(dmi, chromebook_kb_backlight_dmi_table);
 


### PR DESCRIPTION
vendor as "Google" and not "GOOGLE" as expected with the driver. I
have extended the one file to include matches for both.

This is my first kernel module patch, so feel free to kick it back with comments.
