### PR TITLE
Fix build issue when using PAX_CONSTIFY_PLUGIN (on a grsec-enabled kernel)

### DIFF
--- a/chromebook_kb_backlight.c
+++ b/chromebook_kb_backlight.c
@@ -49,7 +49,7 @@ static int __init setup_keyboard_backlight(const struct dmi_system_id *id)
 	return 0;
 }
 
-static struct dmi_system_id __initdata chromebook_kb_backlight_dmi_table[] = {
+static struct dmi_system_id __initconst chromebook_kb_backlight_dmi_table[] = {
 	{
 		.ident = "Chromebook pixel - Keyboard backlight",
 		.matches = {


### PR DESCRIPTION
The PAX_CONSTIFY_PLUGIN is a kernel harneding mechanism. Sometimes, it makes builds fail and require patching the original code.

Here is the build error I would normally obtain:
make -C /lib/modules/`uname -r`/build M=$PWD
make[1]: Entering directory '/usr/src/linux-4.7.10-hardened'
  CC [M]  /home/myuser/sources/backlight-driver/chromebook_keyboard_backlight_driver/chromebook_kb_backlight.o
/home/myuser/sources/backlight-driver/chromebook_keyboard_backlight_driver/chromebook_kb_backlight.c:52:40: error: constified variable ‘chromebook_kb_backlight_dmi_table’ placed into writable section ".init.data"
 static struct dmi_system_id __initdata chromebook_kb_backlight_dmi_table[] = {
                                        ^
scripts/Makefile.build:295: recipe for target '/home/myuser/sources/backlight-driver/chromebook_keyboard_backlight_driver/chromebook_kb_backlight.o' failed
make[2]: *** [/home/myuser/sources/backlight-driver/chromebook_keyboard_backlight_driver/chromebook_kb_backlight.o] Error 1
Makefile:1465: recipe for target '_module_/home/myuser/sources/backlight-driver/chromebook_keyboard_backlight_driver' failed
make[1]: *** [_module_/home/myuser/sources/backlight-driver/chromebook_keyboard_backlight_driver] Error 2
make[1]: Leaving directory '/usr/src/linux-4.7.10-hardened'
Makefile:9: recipe for target 'chromebook_kb_backlight' failed
make: *** [chromebook_kb_backlight] Error 2